### PR TITLE
change moniker name to "azure-devops-dotnet"

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -5,7 +5,7 @@
       "build_source_folder": "azure-devops-dotnet",
       "build_output_subfolder": "azure-devops-dotnet",
       "locale": "en-us",
-      "monikers": ["azure-devops-dotnet-latest","azure-devops-dotnet-preview"],
+      "monikers": ["azure-devops-dotnet","azure-devops-dotnet-preview"],
       "moniker_ranges": [],
       "open_to_public_contributors": true,
       "type_mapping": {


### PR DESCRIPTION
changing moniker name to "azure-devops-dotnet" from the orginally created "azure-devops-dotnet-latest" to align with Azure .NET SDK naming convention. 
As requested by @wnjenkin