### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,32 @@
 ## .NET SDK for Azure DevOps
+
 [![Build Status](https://apidrop.visualstudio.com/Content%20CI/_apis/build/status/PROD/GitHub_MicrosoftDocs_azure-devops-docs-sdk-dotnet/9bc0bbde-bfc4-adc2-75d5-c487f466b459_master_Microsoft.VisualStudio.Services.ExtensionManagement.WebApi)](https://apidrop.visualstudio.com/Content%20CI/_build/latest?definitionId=1438)
 
-This repository contains C# samples that show you how to integrate with Azure DevOps using our [public client libraries](https://www.nuget.org/profiles/nugetvss). 
+This repository contains C# samples that show you how to integrate with Azure DevOps using our [public client libraries](https://www.nuget.org/profiles/nugetvss).
 
 ## About our client libraries
+
 For .NET developers, the primary (and highly recommended) way to integrate with Azure DevOps and Team Foundation Server is via our public .NET client libraries available on Nuget. [Microsoft.TeamFoundationServer.Client](https://www.nuget.org/packages/Microsoft.TeamFoundationServer.Client) is the most popular Nuget package and contains clients for interacting with work item tracking, Git, version control, build, release management and other services.
 
-See the [Azure DevOps client library documentation](https://docs.microsoft.com/en-us/azure/devops/integrate/concepts/dotnet-client-libraries?view=vsts) for more details.
+See the [Azure DevOps client library documentation](https://docs.microsoft.com/azure/devops/integrate/concepts/dotnet-client-libraries?view=vsts) for more details.
 
 ## Sample SDK Entry
+
 Build.Definition Property
 
-```
+```csharp
 [System.Runtime.Serialization.DataMember(EmitDefaultValue=false)]
 [set: System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public Microsoft.TeamFoundation.Build.WebApi.DefinitionReference Definition { get; set; }
 ```
-You can search for more Azure DevOps namespaces via the [.NET API Browser](https://docs.microsoft.com/en-us/dotnet/api/?term=azure).
+
+You can search for more Azure DevOps namespaces via the [.NET API Browser](https://docs.microsoft.com/dotnet/api/?term=azure).
 
 ## Microsoft Open Source Code of Conduct
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Something missing from the SDK?
+
 Let us know by opening an issue on the [Azure DevOps developer community](https://developercommunity.visualstudio.com/spaces/21/index.html).


### PR DESCRIPTION
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

**Global effort to fix build validation errors**

The Content & Learning team is fixing build validation errors on docs.microsoft.com for the rest of H2. This will eliminate potential accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only build validation fixes and does not change other content.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: @MonicaRush
