### PR TITLE
[METADATA UPDATE] Global metadata changes

### DIFF
--- a/azure-devops-dotnet/docfx.json
+++ b/azure-devops-dotnet/docfx.json
@@ -40,6 +40,8 @@
       ]
     },
     "globalMetadata": {
+      "ms.service": "azure-devops",
+      "ms.subservice": "azure-devops-ref",
       "apiPlatform": "dotnet",
       "breadcrumb_path": "~/breadcrumb/toc.yml",
       "extendBreadcrumb": true,
@@ -47,9 +49,7 @@
       "ms.manager": "douge",
       "searchScope": ["Azure DevOps SDK"],
       "ms.topic": "managed-reference",
-      "ms.prod": "devops",
       "products": ["https://authoring-docs-microsoft.poolparty.biz/devrel/5bd2b3fa-c186-4b92-a3c8-09f22a249d37"],
-      "ms.technology": "devops-ref",
       "feedback_github_repo": "MicrosoftDocs/azure-devops-docs-sdk-dotnet",
       "feedback_product_url": "https://developercommunity.visualstudio.com/spaces/21/index.html"
       


### PR DESCRIPTION
This Pull Request was generated automatically as part of a global effort to improve metadata quality. Please review and merge this Pull Request within 5 days. If you have any questions or concerns about these metadata updates, please contact docs-allowlist-mgmt@microsoft.com. If you are not the correct contact for this content and repository, please notify Metadata-Management@microsoft.com.

Fixing[#707910 Remove ms.technology value devops-ref](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/707910)

If this Pull Request is not merged within 14 days, it will be automatically merged by our system to ensure the timeliness of the metadata update.Please notify Metadata-Management@microsoft.com if you would like Pull Requests for metadata updates to merge automatically in future.

After you accept changes of metadata used in reports and they're merged, standard dashboards and reports will reflect new values, so you'll need to use new filter values.If you have any custom dashboards or Kusto queries, you might need to update those also.



**Why we make metadata updates**
Metadata updates are a normal part of business.For example, we update our metadata to reflect a new product name when a product is rebranded.Metadata updates require content to be updated because some metadata values(slugs) are included in the content(YAML header).
For metadata used internally, these updates make reports cleaner, easier to use, more consistent, and more reflective of current business.For metadata exposed to Learn Platform users, these updates ensure our users are exposed to up-to-date information consistent with their overall Microsoft experience.

**Frequently Asked Questions**
Why does this Pull Request appear to be made by the Repository Owner? We open Pull Requests two different ways.For Git Repos with a permissioned Service Account, we open the request from our org's Service Account.For Git Repos that we either do not have Service Account permission for or the repo is in Azure Dev Ops(ADO) we are able to open the Pull Requests in an automated way, but only with the PR creator as the Repo owner.